### PR TITLE
fixed an attempt to remove non-existent log file

### DIFF
--- a/scripts/test-harness.sh
+++ b/scripts/test-harness.sh
@@ -150,7 +150,7 @@ else
   echo "Iterations: ${ITERATIONS}";
 fi
 
-if [[ ! -e "$LOGFILE" ]]; then rm "$LOGFILE"; fi
+if [[ -e "$LOGFILE" ]]; then rm "$LOGFILE"; fi
 
 # Increase stack size - Fixes crashes in some analyses
 ULIMITS=$(ulimit -s)


### PR DESCRIPTION
This fixes the annoying message from `rm` command when indeed `dataraecheck.log` is not available: 
```bash
rm: cannot remove 'results/log/dataracecheck.log': No such file or directory
```