### PR TITLE
Allow compilation with older compilers

### DIFF
--- a/micro-benchmarks/DRB131-taskdep4-orig-yes.c
+++ b/micro-benchmarks/DRB131-taskdep4-orig-yes.c
@@ -22,16 +22,21 @@ void foo(){
   int x = 0, y = 2;
 
   #pragma omp task depend(inout: x) shared(x)
-  x++;																								//1st Child Task
+  x++;                                                //1st Child Task
 
   #pragma omp task shared(y)
-  y--; 																								// 2nd child task
+  y--;                                                // 2nd child task
 
+#if _OPENMP < 201811
+  #pragma omp task depend(in: x) if(0)                // 1st taskwait
+  {}
+#else
   #pragma omp taskwait depend(in: x)                  // 1st taskwait
+#endif
 
   printf("x=%d\n",x);
   printf("y=%d\n",y);
-  #pragma omp taskwait																// 2nd taskwait
+  #pragma omp taskwait                                // 2nd taskwait
 }
 
 

--- a/micro-benchmarks/DRB132-taskdep4-orig-no.c
+++ b/micro-benchmarks/DRB132-taskdep4-orig-no.c
@@ -20,16 +20,21 @@ void foo(){
   int x = 0, y = 2;
 
   #pragma omp task depend(inout: x) shared(x)
-  x++;																								//1st Child Task
+  x++;                                                //1st Child Task
 
   #pragma omp task shared(y)
-  y--; 																								// 2nd child task
+  y--;                                                // 2nd child task
 
+#if _OPENMP < 201811
+  #pragma omp task depend(in: x) if(0)                // 1st taskwait
+  {}
+#else
   #pragma omp taskwait depend(in: x)                  // 1st taskwait
+#endif
 
   printf("x=%d\n",x);
 
-  #pragma omp taskwait																// 2nd taskwait
+  #pragma omp taskwait                                // 2nd taskwait
 
   printf("y=%d\n",y);
 }

--- a/micro-benchmarks/DRB133-taskdep5-orig-no.c
+++ b/micro-benchmarks/DRB133-taskdep5-orig-no.c
@@ -27,7 +27,12 @@ void foo(){
   #pragma omp task depend(in: x) depend(inout: y) shared(x, y)
   y = y-x;                                                              //2nd child task
 
-  #pragma omp taskwait depend(in: x)                                    // 1st taskwait
+#if _OPENMP < 201811
+  #pragma omp task depend(in: x) if(0)                // 1st taskwait
+  {}
+#else
+  #pragma omp taskwait depend(in: x)                  // 1st taskwait
+#endif
 
   printf("x=%d\n",x);
 

--- a/micro-benchmarks/DRB134-taskdep5-orig-yes.c
+++ b/micro-benchmarks/DRB134-taskdep5-orig-yes.c
@@ -27,7 +27,12 @@ void foo(){
   #pragma omp task depend(in: x) depend(inout: y) shared(x, y)
   y = y-x;                                                         //2nd child task
 
-  #pragma omp taskwait depend(in: x)                               // 1st taskwait
+#if _OPENMP < 201811
+  #pragma omp task depend(in: x) if(0)                // 1st taskwait
+  {}
+#else
+  #pragma omp taskwait depend(in: x)                  // 1st taskwait
+#endif
 
   printf("x=%d\n",x);
   printf("y=%d\n",y);


### PR DESCRIPTION
The tests use an OpenMP 5.0 feature without specific need.
This patch uses the pre-5.0 alternative to allow compilation with compilers not yet supporting this new shortcut.