### PR TITLE
Export TSAN_OPTION="ignore_noninstrumented_modules=1" for tsan execution

### DIFF
--- a/scripts/test-harness.sh
+++ b/scripts/test-harness.sh
@@ -396,7 +396,7 @@ for tool in "${TOOLS[@]}"; do
                 cat tmp.log >> "$LOG_DIR/$logname" || >tmp.log ;;
               tsan-clang)
 #                races=$($MEMCHECK -f "%M" -o "$MEMLOG" "./$exname" $size 2>&1 | tee -a "$LOG_DIR/$logname" | grep -ce 'WARNING: ThreadSanitizer: data race') ;;
-                $TIMEOUTCMD $TIMEOUTMIN"m" $MEMCHECK -f "%M" -o "$MEMLOG" "./$exname" $size &> tmp.log;
+                $TIMEOUTCMD $TIMEOUTMIN"m" $MEMCHECK -f "%M" -o "$MEMLOG" env TSAN_OPTIONS="ignore_noninstrumented_modules=1" "./$exname" $size &> tmp.log;
                 check_return_code $?;
 		echo "testname return $testreturn"
                 races=$(grep -ce 'WARNING: ThreadSanitizer: data race' tmp.log) 
@@ -544,7 +544,7 @@ for tool in "${TOOLS[@]}"; do
                 cat tmp.log >> "$LOG_DIR/$logname" || >tmp.log ;;
               tsan-clang)
 #                races=$($MEMCHECK -f "%M" -o "$MEMLOG" "./$exname" $size 2>&1 | tee -a "$LOG_DIR/$logname" | grep -ce 'WARNING: ThreadSanitizer: data race') ;;
-                $TIMEOUTCMD $TIMEOUTMIN"m" $MEMCHECK -f "%M" -o "$MEMLOG" "./$exname" $size &> tmp.log;
+                $TIMEOUTCMD $TIMEOUTMIN"m" $MEMCHECK -f "%M" -o "$MEMLOG" env TSAN_OPTIONS="ignore_noninstrumented_modules=1" "./$exname" $size &> tmp.log;
                 check_return_code $?;
 		echo "testname return $testreturn"
                 races=$(grep -ce 'WARNING: ThreadSanitizer: data race' tmp.log) 


### PR DESCRIPTION
As archer in LLVM/10 suggests, this environmental variable should be exported during execution. Respecting this export, no FP 
should result from execution with ThreadSanitizer in https://github.com/LLNL/dataracebench/wiki/C-C---Details-Aug-2020. 

@Yaying-llnl-summer can you verify this?
If there are still FP with this export, something is wrong with the installation of clang on the system.

Edit: no FP other than for DRB135-taskdep-mutexinoutset