### PR TITLE
Annotate variable name including index 

### DIFF
--- a/micro-benchmarks/DRB018-plusplus-orig-yes.c
+++ b/micro-benchmarks/DRB018-plusplus-orig-yes.c
@@ -49,8 +49,9 @@ Adding private (outLen) can avoid race condition. But it is wrong semantically.
 Data races on outLen also cause output[outLen++] to have data races.
 
 Data race pairs (we allow two pairs to preserve the original code pattern):
-1. outLen@72:12:W vs. outLen@72:12:W
-2. output[]@72:5:W vs. output[]@72:5:W
+1. outLen@73:12:W vs. outLen@73:12:W
+2. output[]@73:5:W vs. output[]@73:5:W
+   output[outLen++]@73:5:W vs. output[outLen++]@73:5:W
 */
 #include <stdlib.h>
 #include <stdio.h>

--- a/micro-benchmarks/DRB019-plusplus-var-yes.c
+++ b/micro-benchmarks/DRB019-plusplus-var-yes.c
@@ -48,8 +48,9 @@ Race condition on outLen due to unprotected writes.
 Adding private (outLen) can avoid race condition. But it is wrong semantically.
 
 Data race pairs: we allow two pair to preserve the original code pattern.
-1. outLen@72:12:W vs. outLen@72:12:W
-2. output[]@72:5:W vs. output[]@72:5:W
+1. outLen@73:12:W vs. outLen@73:12:W
+2. output[]@73:5:W vs. output[]@73:5:W
+   output[outLen++]@73:5:W vs. output[outLen++]@73:5:W
 */
 #include <stdlib.h>
 #include <stdio.h>

--- a/micro-benchmarks/DRB116-target-teams-orig-yes.c
+++ b/micro-benchmarks/DRB116-target-teams-orig-yes.c
@@ -48,7 +48,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 /*
 use of omp target + teams 
 Without protection, master threads from two teams cause data races.
-Data race pair: a@66:5:W vs. a@66:5:W
+Data race pair: a[50]@66:5:W vs. a[50]@66:5:W
 */
 int main(int argc, char* argv[])
 {

--- a/micro-benchmarks/DRB156-missingordered-orig-gpu-yes.c
+++ b/micro-benchmarks/DRB156-missingordered-orig-gpu-yes.c
@@ -8,7 +8,7 @@
 */
 
 /*This example is referred from DRACC by Adrian Schmitz et al.
-Missing ordered directive causes data race pairs var@28:5:W vs. var@28:13:R
+Missing ordered directive causes data race pairs var[i]@28:5:W vs. var[i-1]@28:12:R
 */
 
 #include <stdio.h>

--- a/micro-benchmarks/DRB157-missingorderedsimd-orig-gpu-yes.c
+++ b/micro-benchmarks/DRB157-missingorderedsimd-orig-gpu-yes.c
@@ -11,7 +11,7 @@
 This kernel is modifie version from “DataRaceOnAccelerator A Micro-benchmark Suite for Evaluating
 Correctness Tools Targeting Accelerators” by Adrian Schmitz et al.
 Due to distribute parallel for simd directive at line 31, there is a data race at line 33.
-Data Rae Pairs, var@33:5:W vs. var@33:12:R
+Data Race Pairs, var[i]@33:5:W vs. var[i-C]@33:12:R
 .*/
 
 #include <stdio.h>

--- a/micro-benchmarks/DRB161-nolocksimd-orig-gpu-yes.c
+++ b/micro-benchmarks/DRB161-nolocksimd-orig-gpu-yes.c
@@ -10,7 +10,7 @@
 /* 
 This example is from DRACC by Adrian Schmitz et al.
 Concurrent access on a counter with no lock with simd. Atomicity Violation. Intra Region.
-Data Race Pairs: var@33:7:W vs. var@33:7:W
+Data Race Pairs: var[i]@33:7:W vs. var[i]@33:7:W
 */
 
 #include <stdio.h>

--- a/micro-benchmarks/DRB164-simdmissinglock1-orig-gpu-yes.c
+++ b/micro-benchmarks/DRB164-simdmissinglock1-orig-gpu-yes.c
@@ -11,7 +11,7 @@
 This kernel is referred from “DataRaceOnAccelerator A Micro-benchmark Suite for Evaluating
 Correctness Tools Targeting Accelerators” by Adrian Schmitz et al.
 Concurrent access of var@35:7 without acquiring locks causes atomicity violation. Data race present.
-Data Race Pairs, var@35:7:W vs. var@35:7:W
+Data Race Pairs, var[i]@35:7:W vs. var[i]@35:7:W
 */
 
 #include <stdio.h>


### PR DESCRIPTION
to account for width of the variable access

This alignes the annotation to annotations in other codes