### PR TITLE
Reduce iterations for pi-reduction to reduce execution time

### DIFF
--- a/micro-benchmarks/DRB065-pireduction-orig-no.c
+++ b/micro-benchmarks/DRB065-pireduction-orig-no.c
@@ -48,7 +48,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 Classic PI calculation using reduction    
 */
 
-#define num_steps 2000000000 
+#define num_steps 200000000
 
 #include <stdio.h>
 int main(int argc, char** argv)


### PR DESCRIPTION
Execution time of the benchmark is dominated by the pi code.