### PR TITLE
Actually use the CLANG env variable.

### DIFF
--- a/scripts/test-harness.sh
+++ b/scripts/test-harness.sh
@@ -66,6 +66,7 @@ VALGRIND_COMPILE_C_FLAGS="${OPTIMIZATION} -g -std=c99 -fopenmp"
 VALGRIND_COMPILE_CPP_FLAGS="${OPTIMIZATION} -g -fopenmp"
 
 CLANG=${CLANG:-"clang"}
+CLANGXX=${CLANGXX:-"clang++"}
 TSAN_COMPILE_FLAGS="${OPTIMIZATION} -fopenmp -fsanitize=thread -g"
 
 # Path to LLOV is fixed due to it's only available in container
@@ -357,13 +358,13 @@ for tool in "${TOOLS[@]}"; do
       echo "testing C++ code:$test"
       case "$tool" in 
         gnu)        g++ -g -fopenmp $additional_compile_flags $test -o $exname -lm ;;
-        clang)      clang++ -fopenmp -g $additional_compile_flags $test -o $exname -lm ;;
+        clang)      ${CLANGXX} -fopenmp -g $additional_compile_flags $test -o $exname -lm ;;
         intel)      icpc $ICPC_COMPILE_FLAGS $additional_compile_flags $test -o $exname -lm ;;
         helgrind)   g++ $VALGRIND_COMPILE_CPP_FLAGS $additional_compile_flags $test -o $exname -lm ;;
         archer)     clang-archer++ $ARCHER_COMPILE_FLAGS $additional_compile_flags $test -o $exname -lm ;;
         coderrect)  coderrect -XbcOnly clang++ -fopenmp -fopenmp-version=45 -g ${OPTIMIZATION} $additional_compile_flags $test -o $exname -lm > /dev/null 2>&1 ;;
-        openrace)   clang++ -fopenmp -fopenmp-version=45 -Dmasked=master -g -S -emit-llvm $test -o $exname ;;
-        tsan-clang) clang++ $TSAN_COMPILE_FLAGS $additional_compile_flags $test -o $exname -lm ;;
+        openrace)   ${CLANGXX} -fopenmp -fopenmp-version=45 -Dmasked=master -g -S -emit-llvm $test -o $exname ;;
+        tsan-clang) ${CLANGXX} $TSAN_COMPILE_FLAGS $additional_compile_flags $test -o $exname -lm ;;
         tsan-gcc)   g++ $TSAN_COMPILE_FLAGS $additional_compile_flags $test -o $exname -lm ;;
         llov)       $LLOV_COMPILER/bin/clang++ $LLOV_COMPILE_FLAGS $additional_compile_flags $test -o $exname -lm 2> $compilelog;;
         inspector)  icpc $ICPC_COMPILE_FLAGS $additional_compile_flags $test -o $exname -lm ;;
@@ -374,13 +375,13 @@ for tool in "${TOOLS[@]}"; do
     else
       case "$tool" in 
         gnu)        gcc -g -std=c99 -fopenmp $additional_compile_flags $test -o $exname -lm ;;
-        clang)      clang -fopenmp -g $additional_compile_flags $test -o $exname -lm ;;
+        clang)      ${CLANG} -fopenmp -g $additional_compile_flags $test -o $exname -lm ;;
         intel)      icc $ICC_COMPILE_FLAGS $additional_compile_flags $test -o $exname -lm ;;
         helgrind)   gcc $VALGRIND_COMPILE_C_FLAGS $additional_compile_flags $test -o $exname -lm ;;
         archer)     clang-archer $ARCHER_COMPILE_FLAGS $additional_compile_flags $test -o $exname -lm ;;
         coderrect)  coderrect -XbcOnly clang -fopenmp -fopenmp-version=45 -g ${OPTIMIZATION} $additional_compile_flags $test -o $exname -lm  > /dev/null 2>&1 ;;
-        openrace)   clang -fopenmp -fopenmp-version=45 -Dmasked=master -g -S -emit-llvm $test -o $exname ;;
-        tsan-clang) clang $TSAN_COMPILE_FLAGS $additional_compile_flags $test -o $exname -lm ;;
+        openrace)   ${CLANG} -fopenmp -fopenmp-version=45 -Dmasked=master -g -S -emit-llvm $test -o $exname ;;
+        tsan-clang) ${CLANG} $TSAN_COMPILE_FLAGS $additional_compile_flags $test -o $exname -lm ;;
         tsan-gcc)   gcc $TSAN_COMPILE_FLAGS $additional_compile_flags $test -o $exname -lm ;;
         llov)       $LLOV_COMPILER/bin/clang $LLOV_COMPILE_FLAGS $additional_compile_flags $test -o $exname -lm 2> $compilelog;;
         inspector)  icc $ICC_COMPILE_FLAGS $additional_compile_flags $test -o $exname -lm ;;
@@ -469,7 +470,7 @@ for tool in "${TOOLS[@]}"; do
                 cat tmp.log >> "$LOG_DIR/$logname" || >tmp.log ;;
               tsan-clang)
 #                races=$($MEMCHECK -f "%M" -o "$MEMLOG" "./$exname" $size 2>&1 | tee -a "$LOG_DIR/$logname" | grep -ce 'WARNING: ThreadSanitizer: data race') ;;
-                $TIMEOUTCMD $TIMEOUTMIN"m" $MEMCHECK -f "%M" -o "$MEMLOG" env TSAN_OPTIONS="exitcode=0 ignore_noninstrumented_modules=1" "./$exname" $size &> tmp.log;
+                $TIMEOUTCMD $TIMEOUTMIN"m" $MEMCHECK -f "%M" -o "$MEMLOG" env TSAN_OPTIONS="exitcode=0 halt_on_error=1 ignore_noninstrumented_modules=1" "./$exname" $size &> tmp.log;
                 check_return_code $?;
 		echo "$testname return $testreturn"
                 races=$(grep -ce 'WARNING: ThreadSanitizer: data race' tmp.log) 
@@ -652,7 +653,7 @@ for tool in "${TOOLS[@]}"; do
                 cat tmp.log >> "$LOG_DIR/$logname" || >tmp.log ;;
               tsan-clang)
 #                races=$($MEMCHECK -f "%M" -o "$MEMLOG" "./$exname" $size 2>&1 | tee -a "$LOG_DIR/$logname" | grep -ce 'WARNING: ThreadSanitizer: data race') ;;
-                $TIMEOUTCMD $TIMEOUTMIN"m" $MEMCHECK -f "%M" -o "$MEMLOG" env TSAN_OPTIONS="exitcode=0 ignore_noninstrumented_modules=1" "./$exname" $size &> tmp.log;
+                $TIMEOUTCMD $TIMEOUTMIN"m" $MEMCHECK -f "%M" -o "$MEMLOG" env TSAN_OPTIONS="exitcode=0 halt_on_error=1 ignore_noninstrumented_modules=1" "./$exname" $size &> tmp.log;
                 check_return_code $?;
 		echo "$testname return $testreturn"
                 races=$(grep -ce 'WARNING: ThreadSanitizer: data race' tmp.log) 


### PR DESCRIPTION
Also, halt on error to avoid exhaustive execution time for codes with millions of races

First part of #144.