### PR TITLE
Reduce unnecessary execution time

### DIFF
--- a/micro-benchmarks/DRB065-pireduction-orig-no.c
+++ b/micro-benchmarks/DRB065-pireduction-orig-no.c
@@ -48,7 +48,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 Classic PI calculation using reduction    
 */
 
-#define num_steps 2000000000 
+#define num_steps 200000000
 
 #include <stdio.h>
 int main(int argc, char** argv)

--- a/micro-benchmarks/DRB078-taskdep2-orig-no.c
+++ b/micro-benchmarks/DRB078-taskdep2-orig-no.c
@@ -50,6 +50,7 @@ i is shared for two tasks based on implicit data-sharing attribute rules.
 */
 #include <assert.h> 
 #include <unistd.h>
+#include "signaling.h"
 int main()
 {
   int i=0;
@@ -58,7 +59,7 @@ int main()
   {
 #pragma omp task depend (out:i)
     {
-      sleep(3);
+      delay(10000);
       i = 1;    
     }
 #pragma omp task depend (out:i)

--- a/micro-benchmarks/DRB079-taskdep3-orig-no.c
+++ b/micro-benchmarks/DRB079-taskdep3-orig-no.c
@@ -50,6 +50,7 @@ tasks with depend clauses to ensure execution order, no data races.
 #include <stdio.h> 
 #include <assert.h> 
 #include <unistd.h>
+#include "signaling.h"
 int main()
 {
   int i=0, j, k;
@@ -58,7 +59,7 @@ int main()
   {
 #pragma omp task depend (out:i)
     {
-      sleep(3);
+      delay(10000);
       i = 1;    
     }
 #pragma omp task depend (in:i)

--- a/micro-benchmarks/DRB107-taskgroup-orig-no.c
+++ b/micro-benchmarks/DRB107-taskgroup-orig-no.c
@@ -50,6 +50,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <assert.h>
 #include <unistd.h>
+#include "signaling.h"
 
 int main()
 {
@@ -62,7 +63,7 @@ int main()
       {
 #pragma omp task
         {
-          sleep(3);
+          delay(10000);
           result = 1; 
         }
       }

--- a/micro-benchmarks/DRB190-critical-section2-no.c
+++ b/micro-benchmarks/DRB190-critical-section2-no.c
@@ -16,21 +16,22 @@
 
 #include <stdio.h>
 
-int cap = 10, size = 0;
+int cap = 10, size = 0, packages = 1000;
 unsigned r = 0;
 
 int main()
 {
-#pragma omp parallel sections shared(size, cap) firstprivate(r) num_threads(2)
+#pragma omp parallel sections shared(size, cap) firstprivate(r, packages) num_threads(2)
   {
 #pragma omp section
-    while (1)
+    while (packages)
     {
 #pragma omp critical
       {
         if (size < cap)
         {
           size++; // produce
+          packages--; // produced a package
           printf("Produced! size=%d\n", size);
           fflush(stdout);
         }
@@ -39,18 +40,19 @@ int main()
         r = (r + 1) % 10;
     }
 #pragma omp section
-    while (1)
+    while (packages)
     {
 #pragma omp critical
       {
         if (size > 0)
         {
           size--; // consume
+          packages--; // consumed a package
           printf("Consumed! size=%d\n", size);
           fflush(stdout);
         }
       }
-      for (int i = 0; i < 1000; i++)
+      for (int i = 0; i < 1500; i++)
         r = (r + 1) % 10;
     }
   }

--- a/micro-benchmarks/DRB193-critical-section3-yes.c
+++ b/micro-benchmarks/DRB193-critical-section3-yes.c
@@ -12,7 +12,8 @@
  * Wenhao Wu and Stephen F. Siegel @Univ. of Delaware.
 
  * Race due to different critical section names
- * Data race pair: x@26:7:W vs. x@43:7:W
+ * Data race pair: x@27:7:W vs. x@44:7:W
+ * Data race pair: s@30:9:W vs. s@40:15:R
  */
 
 #include <stdio.h>

--- a/micro-benchmarks/DRB198-prodcons-no.c
+++ b/micro-benchmarks/DRB198-prodcons-no.c
@@ -16,31 +16,33 @@
 
 #include <stdio.h>
 int nprod = 4, ncons = 4;
-int cap = 5, size = 0;
+int cap = 5, size = 0, packages = 1000;
 int main()
 {
   int nthread = nprod + ncons;
-#pragma omp parallel for shared(size, cap, nprod, ncons, nthread) num_threads(nthread)
+#pragma omp parallel for shared(size, cap, nprod, ncons, nthread) firstprivate(packages) num_threads(nthread)
   for (int i = 0; i < nthread; i++)
   {
     if (i < nprod)
-      while (1)
+      while (packages)
       { // I am a producer
 #pragma omp critical
         if (size < cap)
         {
           size++; // produce
+          packages--; // produced a package
           printf("Producer %d produced! size=%d\n", i, size);
           fflush(stdout);
         }
       }
     else
-      while (1)
+      while (packages)
       { // I am a consumer
 #pragma omp critical
         if (size > 0)
         {
           size--; // consume
+          packages--; // consumed a package
           printf("Consumer %d consumed! size=%d\n", i - nprod, size);
           fflush(stdout);
         }

--- a/micro-benchmarks/DRB199-prodcons-yes.c
+++ b/micro-benchmarks/DRB199-prodcons-yes.c
@@ -16,33 +16,34 @@
  */
 
 #include <stdio.h>
-#include <stdio.h>
 int nprod = 4, ncons = 4;
-int cap = 5, size = 0;
+int cap = 5, size = 0, packages = 1000;
 int main()
 {
   int nthread = nprod + ncons;
-#pragma omp parallel for shared(size, cap, nprod, ncons, nthread) num_threads(nthread)
+#pragma omp parallel for shared(size, cap, nprod, ncons, nthread) firstprivate(packages) num_threads(nthread)
   for (int i = 0; i < nthread; i++)
   {
     if (i < nprod)
-      while (1)
+      while (packages)
       { // I am a producer
 #pragma omp critical(A)
         if (size < cap)
         {
           size++; // produce
+          packages--; // produced a package
           printf("Producer %d produced! size=%d\n", i, size);
           fflush(stdout);
         }
       }
     else
-      while (1)
+      while (packages)
       { // I am a consumer
 #pragma omp critical(B)
         if (size > 0)
         {
           size--; // consume
+          packages--; // consumed a package
           printf("Consumer %d consumed! size=%d\n", i - nprod, size);
           fflush(stdout);
         }

--- a/micro-benchmarks/signaling.h
+++ b/micro-benchmarks/signaling.h
@@ -1,0 +1,29 @@
+#if defined(WIN32) || defined(_WIN32)
+#include <windows.h>
+#define delay() Sleep(1);
+#else
+#include <unistd.h>
+#define delay(t) usleep(t);
+#endif
+
+// These functions are used to provide a signal-wait mechanism to enforce expected scheduling for the test cases.
+// Conditional variable (s) needs to be shared! Initialize to 0
+
+#define SIGNAL(s) atomic_signal(&s)
+void atomic_signal(int* s)
+{
+  #pragma omp atomic
+  (*s)++;
+}
+
+#define WAIT(s,v) atomic_wait(&s,v)
+// wait for s >= v
+void atomic_wait(int *s, int v)
+{
+  int wait=0;
+  do{
+    delay(100);
+    #pragma omp atomic read
+	  wait = (*s);
+  }while(wait<v);
+}


### PR DESCRIPTION
- Replace infinite loop by finite loop (would only be terminated by 5 minutes timeout)
- Replace sleep(3) by usleep(10000): 3s -> 10ms
- Reduce number of iterations in pireduction code by one order of magnitude

This cuts down the total execution time to below few minutes with Archer.