### PR TITLE
More than one team is necessary for a data race to be possible

### DIFF
--- a/micro-benchmarks/DRB144-critical-missingreduction-orig-gpu-yes.c
+++ b/micro-benchmarks/DRB144-critical-missingreduction-orig-gpu-yes.c
@@ -20,7 +20,7 @@ int var = 0;
 
 int main(){
   #pragma omp target map(tofrom:var) device(0)
-  #pragma omp teams distribute parallel for
+  #pragma omp teams distribute parallel for num_teams(4)
   for(int i=0; i<N*2; i++){
     #pragma omp critical
     var++;

--- a/micro-benchmarks/DRB150-missinglock1-orig-gpu-yes.c
+++ b/micro-benchmarks/DRB150-missinglock1-orig-gpu-yes.c
@@ -24,7 +24,7 @@ int main(){
   omp_init_lock(&lck);
 
   #pragma omp target map(tofrom:var) device(0)
-  #pragma omp teams distribute parallel for
+  #pragma omp teams distribute parallel for num_teams(4)
   for (int i=0; i<100; i++){
     omp_set_lock(&lck);
     var++;

--- a/micro-benchmarks/DRB160-nobarrier-orig-gpu-yes.c
+++ b/micro-benchmarks/DRB160-nobarrier-orig-gpu-yes.c
@@ -35,7 +35,7 @@ int main(){
 
   #pragma omp target map(tofrom:b[0:C]) map(to:c[0:C],temp[0:C],a) device(0)
   {
-    #pragma omp teams
+    #pragma omp teams num_teams(4)
     for(int i=0; i<N ;i++){
       #pragma omp distribute
       for(int i=0; i<C; i++){


### PR DESCRIPTION
The presence of a race is still dependent on the implementation choice for locking on a device. With more than one team, there is at least the chance to have a race.